### PR TITLE
Temperature scale selection & More information

### DIFF
--- a/arduino/KmanSonoff_v1.00sc/KmanSonoff_v1.00sc.ino
+++ b/arduino/KmanSonoff_v1.00sc/KmanSonoff_v1.00sc.ino
@@ -329,17 +329,18 @@ void checkWallSwitch() {
 #ifdef TEMP
 void getTemp() {
   Serial.print("DHT read . . . . . . . . . . . . . . . . . ");
-  float dhtH, dhtT;
+  float dhtH, dhtT, dhtHI;
   char message_buff[60];
   dhtH = dht.readHumidity();
-  dhtT = dht.readTemperature();
+  dhtT = dht.readTemperature(UseFahrenheit);
+  dhtHI = dht.computeHeatIndex(dhtT, dhtH, UseFahrenheit);
   if(digitalRead(LED) == LOW)  {
     blinkLED(LED, 100, 1);
   } else {
     blinkLED(LED, 100, 1);
     digitalWrite(LED, HIGH);
   }
-  if (isnan(dhtH) || isnan(dhtT)) {
+  if (isnan(dhtH) || isnan(dhtT) || isnan(dhtHI)) {
     if (kRetain == 0) {
       mqttClient.publish(MQTT::Publish(MQTT_TOPIC"/debug","\"DHT Read Error\"").set_qos(QOS));
     } else {
@@ -349,7 +350,7 @@ void getTemp() {
     tempReport = false;
     return;
   }
-  String pubString = "{\"Temp\": "+String(dhtT)+", "+"\"Humidity\": "+String(dhtH) + "}";
+  String pubString = "{\"Temp\": "+String(dhtT)+", "+"\"Humidity\": "+String(dhtH)+", "+"\"HeatIndex\": "+String(dhtHI) + "}";
   pubString.toCharArray(message_buff, pubString.length()+1);
   if (kRetain == 0) {
     mqttClient.publish(MQTT::Publish(MQTT_TOPIC"/temp", message_buff).set_qos(QOS));

--- a/arduino/KmanSonoff_v1.00sc/config_sc.h
+++ b/arduino/KmanSonoff_v1.00sc/config_sc.h
@@ -13,13 +13,14 @@ int QOS = 0;                                                  // QOS level for a
 
 #define NONE                                                  // Set to NONE, TEMP, or WS (Cannot be blank)
                                                               // NONE for standard Sonoff relay only ON / OFF (default)
-                                                              // TEMP for DHT11/22 Support on Pin 5 of header (GPIO 14)
+                                                              // TEMP for DHT11/22 Support on Pin 5 of header (GPIO 14)  **Must install 'DHT sensor library' (Adafruit) & 'Adafruit Unified Sensor' library.
                                                               // WS for External Wallswitch Support on Pin 5 of header (GPIO 14)
 
 #define ORIG                                                  // ORIG or TH
                                                               // ORIG for Basic / Original Sonoff, TH for TH Series
 
-#define DHTTYPE          DHT22                                // Set DHT Type to 11 or 22. N/A if using WS or NONE.
+#define DHTTYPE          DHT22                                // Set to 'DHT11' or 'DHT22'. (Only applies if using TEMP)  **Must connect to the mains power for temperature readings to be sent.
+#define UseFahrenheit    false                                // Set to 'true' to use Fahrenheit. (Only applies if using TEMP)
 
 #define MQTT_SERVER      "192.168.0.100"                      // Your mqtt server ip address
 #define MQTT_PORT        1883                                 // Your mqtt port

--- a/home-assistant/sensors.yaml
+++ b/home-assistant/sensors.yaml
@@ -2,12 +2,22 @@
   name: "Living Room Temp"
   state_topic: "home/sonoff/living_room/1/temp"
   qos: 1
+  # Set unit_of_measurement to "°C" or "°F" to match the temperature scale chosen in config_sc.h
   unit_of_measurement: "°C"
-  value_template: "{{ value_json.Temp }}"
+  value_template: "{{ value_json.Temp | round(1) }}"
 
 - platform: mqtt
   name: "Living Room Humidity"
   state_topic: "home/sonoff/living_room/1/temp"
   qos: 1
   unit_of_measurement: "%"
-  value_template: "{{ value_json.Humidity }}"
+  value_template: "{{ value_json.Humidity | round(1) }}"
+
+- platform: mqtt
+  state_topic: "home/sonoff/living_room/1/temp"
+  name: "Living Room Real Feel"
+  qos: 1
+  # Set unit_of_measurement to "°C" or "°F" to match the temperature scale chosen in config_sc.h
+  unit_of_measurement: "°C"
+  value_template: "{{ value_json.HeatIndex | round(1) }}"
+  


### PR DESCRIPTION
+++++++++++++
config_sc.h-
Mentioned specific libraries required for TEMP and that the Sonoff needs to be on the mains for readings to be sent (hopefully reduce repeat questions).

Added variable to allow selection/use of Celsius or Fahrenheit.

+++++++++++++
KmanSonoff_v1.00sc.ino-
Included variable to process temperatures according to scale selected in config_sc.h.

Added float variable for Heat Index calculation.

Modified 'if (isnan)' check & related MQTT pubString to pass the Heat-Index calculation to Home Assistant.

+++++++++++++
sensors.yaml-
Rounded measurements to a single decimal point.

Added a reminder to match selected temperature scale for display units.

Added Heat Index (a.k.a Real Feel) sensor.